### PR TITLE
adds scaffolding for a contest

### DIFF
--- a/lib/pool/contests.ex
+++ b/lib/pool/contests.ex
@@ -1,0 +1,104 @@
+defmodule Pool.Contests do
+  @moduledoc """
+  The Contests context.
+  """
+
+  import Ecto.Query, warn: false
+  alias Pool.Repo
+
+  alias Pool.Contests.Contest
+
+  @doc """
+  Returns the list of contests.
+
+  ## Examples
+
+      iex> list_contests()
+      [%Contest{}, ...]
+
+  """
+  def list_contests do
+    Repo.all(Contest)
+  end
+
+  @doc """
+  Gets a single contest.
+
+  Raises `Ecto.NoResultsError` if the Contest does not exist.
+
+  ## Examples
+
+      iex> get_contest!(123)
+      %Contest{}
+
+      iex> get_contest!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_contest!(id), do: Repo.get!(Contest, id)
+
+  @doc """
+  Creates a contest.
+
+  ## Examples
+
+      iex> create_contest(%{field: value})
+      {:ok, %Contest{}}
+
+      iex> create_contest(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_contest(attrs \\ %{}) do
+    %Contest{}
+    |> Contest.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a contest.
+
+  ## Examples
+
+      iex> update_contest(contest, %{field: new_value})
+      {:ok, %Contest{}}
+
+      iex> update_contest(contest, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_contest(%Contest{} = contest, attrs) do
+    contest
+    |> Contest.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a contest.
+
+  ## Examples
+
+      iex> delete_contest(contest)
+      {:ok, %Contest{}}
+
+      iex> delete_contest(contest)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_contest(%Contest{} = contest) do
+    Repo.delete(contest)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking contest changes.
+
+  ## Examples
+
+      iex> change_contest(contest)
+      %Ecto.Changeset{data: %Contest{}}
+
+  """
+  def change_contest(%Contest{} = contest, attrs \\ %{}) do
+    Contest.changeset(contest, attrs)
+  end
+end

--- a/lib/pool/contests/contest.ex
+++ b/lib/pool/contests/contest.ex
@@ -1,0 +1,17 @@
+defmodule Pool.Contests.Contest do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "contests" do
+    field :name, :string
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(contest, attrs) do
+    contest
+    |> cast(attrs, [:name])
+    |> validate_required([:name])
+  end
+end

--- a/lib/pool_web/controllers/contest_controller.ex
+++ b/lib/pool_web/controllers/contest_controller.ex
@@ -1,0 +1,62 @@
+defmodule PoolWeb.ContestController do
+  use PoolWeb, :controller
+
+  alias Pool.Contests
+  alias Pool.Contests.Contest
+
+  def index(conn, _params) do
+    contests = Contests.list_contests()
+    render(conn, "index.html", contests: contests)
+  end
+
+  def new(conn, _params) do
+    changeset = Contests.change_contest(%Contest{})
+    render(conn, "new.html", changeset: changeset)
+  end
+
+  def create(conn, %{"contest" => contest_params}) do
+    case Contests.create_contest(contest_params) do
+      {:ok, contest} ->
+        conn
+        |> put_flash(:info, "Contest created successfully.")
+        |> redirect(to: Routes.contest_path(conn, :show, contest))
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        render(conn, "new.html", changeset: changeset)
+    end
+  end
+
+  def show(conn, %{"id" => id}) do
+    contest = Contests.get_contest!(id)
+    render(conn, "show.html", contest: contest)
+  end
+
+  def edit(conn, %{"id" => id}) do
+    contest = Contests.get_contest!(id)
+    changeset = Contests.change_contest(contest)
+    render(conn, "edit.html", contest: contest, changeset: changeset)
+  end
+
+  def update(conn, %{"id" => id, "contest" => contest_params}) do
+    contest = Contests.get_contest!(id)
+
+    case Contests.update_contest(contest, contest_params) do
+      {:ok, contest} ->
+        conn
+        |> put_flash(:info, "Contest updated successfully.")
+        |> redirect(to: Routes.contest_path(conn, :show, contest))
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        render(conn, "edit.html", contest: contest, changeset: changeset)
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    contest = Contests.get_contest!(id)
+    {:ok, _contest} = Contests.delete_contest(contest)
+
+    conn
+    |> put_flash(:info, "Contest deleted successfully.")
+    |> redirect(to: Routes.contest_path(conn, :index))
+  end
+end

--- a/lib/pool_web/router.ex
+++ b/lib/pool_web/router.ex
@@ -21,6 +21,8 @@ defmodule PoolWeb.Router do
     pipe_through :browser
 
     get "/", PageController, :index
+
+    resources "/contests", ContestController
   end
 
   # Other scopes may use custom stacks.

--- a/lib/pool_web/templates/contest/edit.html.heex
+++ b/lib/pool_web/templates/contest/edit.html.heex
@@ -1,0 +1,5 @@
+<h1>Edit Contest</h1>
+
+<%= render "form.html", Map.put(assigns, :action, Routes.contest_path(@conn, :update, @contest)) %>
+
+<span><%= link "Back", to: Routes.contest_path(@conn, :index) %></span>

--- a/lib/pool_web/templates/contest/form.html.heex
+++ b/lib/pool_web/templates/contest/form.html.heex
@@ -1,0 +1,15 @@
+<.form let={f} for={@changeset} action={@action}>
+  <%= if @changeset.action do %>
+    <div class="alert alert-danger">
+      <p>Oops, something went wrong! Please check the errors below.</p>
+    </div>
+  <% end %>
+
+  <%= label f, :name %>
+  <%= text_input f, :name %>
+  <%= error_tag f, :name %>
+
+  <div>
+    <%= submit "Save" %>
+  </div>
+</.form>

--- a/lib/pool_web/templates/contest/index.html.heex
+++ b/lib/pool_web/templates/contest/index.html.heex
@@ -1,0 +1,26 @@
+<h1>Listing Contests</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>Name</th>
+
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+<%= for contest <- @contests do %>
+    <tr>
+      <td><%= contest.name %></td>
+
+      <td>
+        <span><%= link "Show", to: Routes.contest_path(@conn, :show, contest) %></span>
+        <span><%= link "Edit", to: Routes.contest_path(@conn, :edit, contest) %></span>
+        <span><%= link "Delete", to: Routes.contest_path(@conn, :delete, contest), method: :delete, data: [confirm: "Are you sure?"] %></span>
+      </td>
+    </tr>
+<% end %>
+  </tbody>
+</table>
+
+<span><%= link "New Contest", to: Routes.contest_path(@conn, :new) %></span>

--- a/lib/pool_web/templates/contest/new.html.heex
+++ b/lib/pool_web/templates/contest/new.html.heex
@@ -1,0 +1,5 @@
+<h1>New Contest</h1>
+
+<%= render "form.html", Map.put(assigns, :action, Routes.contest_path(@conn, :create)) %>
+
+<span><%= link "Back", to: Routes.contest_path(@conn, :index) %></span>

--- a/lib/pool_web/templates/contest/show.html.heex
+++ b/lib/pool_web/templates/contest/show.html.heex
@@ -1,0 +1,13 @@
+<h1>Show Contest</h1>
+
+<ul>
+
+  <li>
+    <strong>Name:</strong>
+    <%= @contest.name %>
+  </li>
+
+</ul>
+
+<span><%= link "Edit", to: Routes.contest_path(@conn, :edit, @contest) %></span> |
+<span><%= link "Back", to: Routes.contest_path(@conn, :index) %></span>

--- a/lib/pool_web/templates/layout/_header.html.heex
+++ b/lib/pool_web/templates/layout/_header.html.heex
@@ -25,7 +25,7 @@
         <div class="hidden sm:block sm:ml-6">
           <div class="flex space-x-4">
             <a href="#" class="text-blue hover:bg-gray-700 hover:text-blue-hover px-3 py-2 rounded-md text-sm font-medium">Dashboard</a>
-            <a href="#" class="text-blue hover:bg-gray-700 hover:text-blue-hover px-3 py-2 rounded-md text-sm font-medium">My Pools</a>
+            <%= link "My Pools", to: Routes.contest_path(@conn, :index), class: "text-blue hover:bg-gray-700 hover:text-blue-hover px-3 py-2 rounded-md text-sm font-medium"%>
             <a href="#" class="text-blue hover:bg-gray-700 hover:text-blue-hover px-3 py-2 rounded-md text-sm font-medium">Find a Pool</a>
             <a href="#" class="text-blue hover:bg-gray-700 hover:text-blue-hover px-3 py-2 rounded-md text-sm font-medium">Create a Pool</a>
           </div>

--- a/lib/pool_web/views/contest_view.ex
+++ b/lib/pool_web/views/contest_view.ex
@@ -1,0 +1,3 @@
+defmodule PoolWeb.ContestView do
+  use PoolWeb, :view
+end

--- a/priv/repo/migrations/20220128041807_create_contests.exs
+++ b/priv/repo/migrations/20220128041807_create_contests.exs
@@ -1,0 +1,11 @@
+defmodule Pool.Repo.Migrations.CreateContests do
+  use Ecto.Migration
+
+  def change do
+    create table(:contests) do
+      add :name, :string
+
+      timestamps()
+    end
+  end
+end

--- a/test/pool/contests_test.exs
+++ b/test/pool/contests_test.exs
@@ -1,0 +1,59 @@
+defmodule Pool.ContestsTest do
+  use Pool.DataCase
+
+  alias Pool.Contests
+
+  describe "contests" do
+    alias Pool.Contests.Contest
+
+    import Pool.ContestsFixtures
+
+    @invalid_attrs %{name: nil}
+
+    test "list_contests/0 returns all contests" do
+      contest = contest_fixture()
+      assert Contests.list_contests() == [contest]
+    end
+
+    test "get_contest!/1 returns the contest with given id" do
+      contest = contest_fixture()
+      assert Contests.get_contest!(contest.id) == contest
+    end
+
+    test "create_contest/1 with valid data creates a contest" do
+      valid_attrs = %{name: "some name"}
+
+      assert {:ok, %Contest{} = contest} = Contests.create_contest(valid_attrs)
+      assert contest.name == "some name"
+    end
+
+    test "create_contest/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Contests.create_contest(@invalid_attrs)
+    end
+
+    test "update_contest/2 with valid data updates the contest" do
+      contest = contest_fixture()
+      update_attrs = %{name: "some updated name"}
+
+      assert {:ok, %Contest{} = contest} = Contests.update_contest(contest, update_attrs)
+      assert contest.name == "some updated name"
+    end
+
+    test "update_contest/2 with invalid data returns error changeset" do
+      contest = contest_fixture()
+      assert {:error, %Ecto.Changeset{}} = Contests.update_contest(contest, @invalid_attrs)
+      assert contest == Contests.get_contest!(contest.id)
+    end
+
+    test "delete_contest/1 deletes the contest" do
+      contest = contest_fixture()
+      assert {:ok, %Contest{}} = Contests.delete_contest(contest)
+      assert_raise Ecto.NoResultsError, fn -> Contests.get_contest!(contest.id) end
+    end
+
+    test "change_contest/1 returns a contest changeset" do
+      contest = contest_fixture()
+      assert %Ecto.Changeset{} = Contests.change_contest(contest)
+    end
+  end
+end

--- a/test/pool_web/controllers/contest_controller_test.exs
+++ b/test/pool_web/controllers/contest_controller_test.exs
@@ -1,0 +1,84 @@
+defmodule PoolWeb.ContestControllerTest do
+  use PoolWeb.ConnCase
+
+  import Pool.ContestsFixtures
+
+  @create_attrs %{name: "some name"}
+  @update_attrs %{name: "some updated name"}
+  @invalid_attrs %{name: nil}
+
+  describe "index" do
+    test "lists all contests", %{conn: conn} do
+      conn = get(conn, Routes.contest_path(conn, :index))
+      assert html_response(conn, 200) =~ "Listing Contests"
+    end
+  end
+
+  describe "new contest" do
+    test "renders form", %{conn: conn} do
+      conn = get(conn, Routes.contest_path(conn, :new))
+      assert html_response(conn, 200) =~ "New Contest"
+    end
+  end
+
+  describe "create contest" do
+    test "redirects to show when data is valid", %{conn: conn} do
+      conn = post(conn, Routes.contest_path(conn, :create), contest: @create_attrs)
+
+      assert %{id: id} = redirected_params(conn)
+      assert redirected_to(conn) == Routes.contest_path(conn, :show, id)
+
+      conn = get(conn, Routes.contest_path(conn, :show, id))
+      assert html_response(conn, 200) =~ "Show Contest"
+    end
+
+    test "renders errors when data is invalid", %{conn: conn} do
+      conn = post(conn, Routes.contest_path(conn, :create), contest: @invalid_attrs)
+      assert html_response(conn, 200) =~ "New Contest"
+    end
+  end
+
+  describe "edit contest" do
+    setup [:create_contest]
+
+    test "renders form for editing chosen contest", %{conn: conn, contest: contest} do
+      conn = get(conn, Routes.contest_path(conn, :edit, contest))
+      assert html_response(conn, 200) =~ "Edit Contest"
+    end
+  end
+
+  describe "update contest" do
+    setup [:create_contest]
+
+    test "redirects when data is valid", %{conn: conn, contest: contest} do
+      conn = put(conn, Routes.contest_path(conn, :update, contest), contest: @update_attrs)
+      assert redirected_to(conn) == Routes.contest_path(conn, :show, contest)
+
+      conn = get(conn, Routes.contest_path(conn, :show, contest))
+      assert html_response(conn, 200) =~ "some updated name"
+    end
+
+    test "renders errors when data is invalid", %{conn: conn, contest: contest} do
+      conn = put(conn, Routes.contest_path(conn, :update, contest), contest: @invalid_attrs)
+      assert html_response(conn, 200) =~ "Edit Contest"
+    end
+  end
+
+  describe "delete contest" do
+    setup [:create_contest]
+
+    test "deletes chosen contest", %{conn: conn, contest: contest} do
+      conn = delete(conn, Routes.contest_path(conn, :delete, contest))
+      assert redirected_to(conn) == Routes.contest_path(conn, :index)
+
+      assert_error_sent 404, fn ->
+        get(conn, Routes.contest_path(conn, :show, contest))
+      end
+    end
+  end
+
+  defp create_contest(_) do
+    contest = contest_fixture()
+    %{contest: contest}
+  end
+end

--- a/test/support/fixtures/contests_fixtures.ex
+++ b/test/support/fixtures/contests_fixtures.ex
@@ -1,0 +1,20 @@
+defmodule Pool.ContestsFixtures do
+  @moduledoc """
+  This module defines test helpers for creating
+  entities via the `Pool.Contests` context.
+  """
+
+  @doc """
+  Generate a contest.
+  """
+  def contest_fixture(attrs \\ %{}) do
+    {:ok, contest} =
+      attrs
+      |> Enum.into(%{
+        name: "some name"
+      })
+      |> Pool.Contests.create_contest()
+
+    contest
+  end
+end


### PR DESCRIPTION
This creates the boiler plate and basis for our concept of a "contest". Couldn't use "Pool" because the app name is also called Pool. Oh well.

The schema is just a name at the moment. This can evolve.

if you click on the my pools tab it should take you to an (unstyled) pools page. Should be able to create/edit from there.

If you/re interested `mix phx.gen.html Contests Contest contests name:string` is what generated this