### PR TITLE
More sports api data

### DIFF
--- a/lib/pool/contests.ex
+++ b/lib/pool/contests.ex
@@ -40,6 +40,23 @@ defmodule Pool.Contests do
     Repo.all(query)
   end
 
+  def joined_contests_needing_picks(user_id) do
+    query =
+      from c in Contest,
+        join: u in assoc(c, :users),
+        preload: [users: u],
+        where: u.id == ^user_id,
+        join: g in assoc(c, :games),
+        preload: [games: g],
+        left_join: p in assoc(c, :picks),
+        preload: [picks: p],
+        # having: count(p.id) < count(g.id),
+        where: p.game_id in [g.id]
+        # group_by: [g.id, c.id, p.id, u.id]
+
+    Repo.all(query)
+  end
+
   @doc """
   Gets a single contest.
 
@@ -73,6 +90,7 @@ defmodule Pool.Contests do
   """
   def create_contest(user, attrs \\ %{}) do
     IO.inspect(attrs, label: "1")
+
     %Contest{}
     |> Contest.changeset(attrs)
     |> Ecto.Changeset.put_assoc(:owner_account, user)

--- a/lib/pool/contests.ex
+++ b/lib/pool/contests.ex
@@ -52,7 +52,21 @@ defmodule Pool.Contests do
         preload: [picks: p],
         # having: count(p.id) < count(g.id),
         where: p.game_id in [g.id]
-        # group_by: [g.id, c.id, p.id, u.id]
+
+    # group_by: [g.id, c.id, p.id, u.id]
+
+    Repo.all(query)
+  end
+
+  def next_game_start(contest_id) do
+    query =
+      from(
+        g in Pool.Games.Game,
+        join: c in assoc(g, :contests),
+        where: c.id == ^contest_id,
+        group_by: [c.id],
+        select: min(g.start)
+      )
 
     Repo.all(query)
   end

--- a/lib/pool/games/game.ex
+++ b/lib/pool/games/game.ex
@@ -6,6 +6,9 @@ defmodule Pool.Games.Game do
     field :over_under, :decimal
     field :spread, :decimal
     field :start, :utc_datetime
+    field :forecast_temp, :integer
+    field :forecast_desc, :string
+    field :forecast_wind, :integer
 
     belongs_to :home_team, Pool.Games.Team
     belongs_to :away_team, Pool.Games.Team
@@ -17,8 +20,8 @@ defmodule Pool.Games.Game do
   @doc false
   def changeset(game, attrs) do
     game
-    |> cast(attrs, [:start, :spread, :over_under])
-    |> validate_required([:start, :spread, :over_under])
+    |> cast(attrs, [:start, :spread, :over_under, :forecast_temp, :forecast_desc, :forecast_wind])
+    |> validate_required([:start, :spread, :over_under, :forecast_temp, :forecast_desc, :forecast_wind])
   end
 
   def teams_changeset(game, home_team, away_team) do

--- a/lib/pool/games/team.ex
+++ b/lib/pool/games/team.ex
@@ -5,6 +5,13 @@ defmodule Pool.Games.Team do
   schema "teams" do
     field :logo, :string
     field :name, :string
+    field :name, :string
+    field :city, :string
+    field :key, :string
+    field :conference, :string
+    field :division, :string
+    field :stadium_details, :string
+    field :colors, {:map, :string}
 
     has_many :away_games, Pool.Games.Game, foreign_key: :home_team_id
     has_many :home_games, Pool.Games.Game, foreign_key: :away_team_id

--- a/lib/pool/games/team.ex
+++ b/lib/pool/games/team.ex
@@ -5,12 +5,11 @@ defmodule Pool.Games.Team do
   schema "teams" do
     field :logo, :string
     field :name, :string
-    field :name, :string
     field :city, :string
     field :key, :string
     field :conference, :string
     field :division, :string
-    field :stadium_details, :string
+    field :stadium_details, :map
     field :colors, {:map, :string}
 
     has_many :away_games, Pool.Games.Game, foreign_key: :home_team_id

--- a/lib/pool/games/team.ex
+++ b/lib/pool/games/team.ex
@@ -3,6 +3,7 @@ defmodule Pool.Games.Team do
   import Ecto.Changeset
 
   schema "teams" do
+    field :global_id, :integer
     field :logo, :string
     field :name, :string
     field :city, :string

--- a/lib/pool/sportsdata.ex
+++ b/lib/pool/sportsdata.ex
@@ -23,4 +23,27 @@ defmodule Pool.SportsData do
     data = make_call(endpoint)
     for %{^key => value} <- data, do: value
   end
+
+  def get_team_details(team_key) do
+    team_keys = Pool.SportsData.get_all_teams("Key")
+    i = Enum.find_index(team_keys, fn t -> t == team_key end)
+    team_details = Enum.zip([Enum.at(team_keys, i)], [map_details(i)]) |> Enum.into(%{})
+    team_details[team_key]
+  end
+
+  def map_details(i) do
+    %{
+      name: Enum.at(Pool.SportsData.get_all_teams("Name"), i),
+      city: Enum.at(Pool.SportsData.get_all_teams("City"), i),
+      conference: Enum.at(Pool.SportsData.get_all_teams("Conference"), i),
+      division: Enum.at(Pool.SportsData.get_all_teams("Division"), i),
+      stadium_details: Enum.at(Pool.SportsData.get_all_teams("StadiumDetails"), i),
+      colors: %{
+        a: Enum.at(Pool.SportsData.get_all_teams("PrimaryColor"), i),
+        b: Enum.at(Pool.SportsData.get_all_teams("SecondaryColor"), i),
+        c: Enum.at(Pool.SportsData.get_all_teams("TertiaryColor"), i),
+        d: Enum.at(Pool.SportsData.get_all_teams("QuaternaryColor"), i)
+      }
+    }
+  end
 end

--- a/lib/pool/sportsdata.ex
+++ b/lib/pool/sportsdata.ex
@@ -31,18 +31,20 @@ defmodule Pool.SportsData do
     team_details[team_key]
   end
 
-  def get_team_details_by_id(team_id) do
-    team_ids = Pool.SportsData.get_all_teams("TeamID")
-    i = Enum.find_index(team_ids, fn t -> t == team_id end)
-    team_details = Enum.zip([Enum.at(team_ids, i)], [map_details(i)]) |> Enum.into(%{})
-    team_details[team_id]
-  end
+  # def get_team_details_by_id(team_id) do
+  #   team_ids = Pool.SportsData.get_all_teams("TeamID")
+  #   i = Enum.find_index(team_ids, fn t -> t == team_id end)
+  #   team_details = Enum.zip([Enum.at(team_ids, i)], [map_details(i)]) |> Enum.into(%{})
+  #   team_details[team_id]
+  # end
 
   def map_details(i) do
     %{
+      key: Enum.at(Pool.SportsData.get_all_teams("Key"), i),
       name: Enum.at(Pool.SportsData.get_all_teams("Name"), i),
       city: Enum.at(Pool.SportsData.get_all_teams("City"), i),
       full_name: Enum.at(Pool.SportsData.get_all_teams("FullName"), i),
+      team_id: Enum.at(Pool.SportsData.get_all_teams("TeamID"), i),
       logo: Enum.at(Pool.SportsData.get_all_teams("WikipediaLogoUrl"), i),
       conference: Enum.at(Pool.SportsData.get_all_teams("Conference"), i),
       division: Enum.at(Pool.SportsData.get_all_teams("Division"), i),

--- a/lib/pool/sportsdata.ex
+++ b/lib/pool/sportsdata.ex
@@ -16,12 +16,17 @@ defmodule Pool.SportsData do
   end
 
   # Data for all current NFL teams
-  @type search_key() :: String.t()
+  @type search_key() :: String.t() | nil
   @spec get_all_teams(search_key()) :: any()
-  def get_all_teams(key) do
+  def get_all_teams(key \\ nil) do
     endpoint = "https://api.sportsdata.io/v3/nfl/scores/json/Teams"
     data = make_call(endpoint)
-    for %{^key => value} <- data, do: value
+
+    if !key do
+      data
+    else
+      for %{^key => value} <- data, do: value
+    end
   end
 
   def get_team_details(team_key) do
@@ -31,20 +36,13 @@ defmodule Pool.SportsData do
     team_details[team_key]
   end
 
-  # def get_team_details_by_id(team_id) do
-  #   team_ids = Pool.SportsData.get_all_teams("TeamID")
-  #   i = Enum.find_index(team_ids, fn t -> t == team_id end)
-  #   team_details = Enum.zip([Enum.at(team_ids, i)], [map_details(i)]) |> Enum.into(%{})
-  #   team_details[team_id]
-  # end
-
   def map_details(i) do
     %{
       key: Enum.at(Pool.SportsData.get_all_teams("Key"), i),
       name: Enum.at(Pool.SportsData.get_all_teams("Name"), i),
       city: Enum.at(Pool.SportsData.get_all_teams("City"), i),
       full_name: Enum.at(Pool.SportsData.get_all_teams("FullName"), i),
-      team_id: Enum.at(Pool.SportsData.get_all_teams("TeamID"), i),
+      global_id: Enum.at(Pool.SportsData.get_all_teams("GlobalTeamID"), i),
       logo: Enum.at(Pool.SportsData.get_all_teams("WikipediaLogoUrl"), i),
       conference: Enum.at(Pool.SportsData.get_all_teams("Conference"), i),
       division: Enum.at(Pool.SportsData.get_all_teams("Division"), i),
@@ -56,5 +54,18 @@ defmodule Pool.SportsData do
         d: Enum.at(Pool.SportsData.get_all_teams("QuaternaryColor"), i)
       }
     }
+  end
+
+  # Data for all games in a season
+  @spec get_all_games(search_key()) :: any()
+  def get_all_games(key \\ nil, season \\ "2021") do
+    endpoint = "https://api.sportsdata.io/v3/nfl/scores/json/Schedules/#{season}"
+    data = make_call(endpoint)
+
+    if !key do
+      data
+    else
+      for %{^key => value} <- data, do: value
+    end
   end
 end

--- a/lib/pool/sportsdata.ex
+++ b/lib/pool/sportsdata.ex
@@ -31,10 +31,19 @@ defmodule Pool.SportsData do
     team_details[team_key]
   end
 
+  def get_team_details_by_id(team_id) do
+    team_ids = Pool.SportsData.get_all_teams("TeamID")
+    i = Enum.find_index(team_ids, fn t -> t == team_id end)
+    team_details = Enum.zip([Enum.at(team_ids, i)], [map_details(i)]) |> Enum.into(%{})
+    team_details[team_id]
+  end
+
   def map_details(i) do
     %{
       name: Enum.at(Pool.SportsData.get_all_teams("Name"), i),
       city: Enum.at(Pool.SportsData.get_all_teams("City"), i),
+      full_name: Enum.at(Pool.SportsData.get_all_teams("FullName"), i),
+      logo: Enum.at(Pool.SportsData.get_all_teams("WikipediaLogoUrl"), i),
       conference: Enum.at(Pool.SportsData.get_all_teams("Conference"), i),
       division: Enum.at(Pool.SportsData.get_all_teams("Division"), i),
       stadium_details: Enum.at(Pool.SportsData.get_all_teams("StadiumDetails"), i),

--- a/lib/pool/sportsdata.ex
+++ b/lib/pool/sportsdata.ex
@@ -102,4 +102,30 @@ defmodule Pool.SportsData do
       pregame_odds: Enum.at(Enum.at(Pool.SportsData.get_game_odds_by_week("PregameOdds"), 0), i)
     }
   end
+
+  def get_forecast(game_id) do
+    game = Enum.find(get_all_games(), fn g -> g["GlobalGameID"] == game_id end)
+    [temp: game["ForecastWindChill"], icon: weather_icon(game["ForecastDescription"]), wind: game["ForecastWindSpeed"]]
+  end
+
+  def weather_icon(desc) do
+    case desc do
+      "Clear Sky" -> "fa-solid fa-sun"
+      "Few Clouds" -> "fa-solid fa-sun-cloud"
+      "Scattered Clouds" -> "fa-solid fa-cloud-sun"
+      "Broken Clouds" -> "fa-solid fa-cloud-sun"
+      "Overcast Clouds" -> "fa-solid fa-clouds-sun"
+      "Light Rain" -> "fa-solid fa-cloud-drizzle"
+      "Moderate Rain" -> "fa-solid fa-cloud-rain"
+      "Heavy Intensity Rain" -> "fa-solid fa-cloud-rain"
+      "Snow" -> "fa-solid fa-snowflakes"
+      nil -> ""
+      # night time icons
+      # "Clear Sky" -> "fa-solid fa-moon-stars"
+      # "Few Clouds" -> "fa-solid fa-moon-cloud"
+      # "Scattered Clouds" -> "fa-solid fa-cloud-moon"
+      # "Overcast Clouds" -> "fa-solid fa-clouds-moon"
+      # "Heavy Intensity Rain" -> "fa-solid fa-cloud-moon-rain"
+    end
+  end
 end

--- a/lib/pool/weather/weather.ex
+++ b/lib/pool/weather/weather.ex
@@ -1,10 +1,20 @@
 defmodule Pool.Weather do
   # OpenWeather API calls
+  alias Pool.SportsData
+
+  def stadium_weather(team) do
+    target = "/data/2.5/weather?"
+    stadium = SportsData.get_team_details(team).stadium_details
+    [lat, lon] = [stadium["GeoLat"], stadium["GeoLong"]]
+    query = %{"lat" => lat, "lon" => lon, "units" => "imperial"}
+    %{main: metrics, weather: [weather | _tail]} = make_call(target, query)
+    %{temp: round(metrics.temp), code: weather.icon}
+  end
 
   # returns temp and weather icon
-  def get_weather() do
+  def get_weather(city, state, country \\ "us") do
     target = "/data/2.5/weather?"
-    [lat, lon] = geocode("los angeles", "ca")
+    [lat, lon] = geocode(city, state)
     query = %{"lat" => lat, "lon" => lon, "units" => "imperial"}
     %{main: metrics, weather: [weather | _tail]} = make_call(target, query)
     %{temp: round(metrics.temp), code: weather.icon}

--- a/lib/pool_web/controllers/hub_controller.ex
+++ b/lib/pool_web/controllers/hub_controller.ex
@@ -2,9 +2,10 @@ defmodule PoolWeb.HubController do
   use PoolWeb, :controller
 
   alias Pool.Weather
+  alias Pool.SportsData
 
   def index(conn, _params) do
     weather_data = Weather.get_weather()
-    render(conn, "index.html", weather: weather_data)
+    render(conn, "index.html", weather: weather_data, team_data: SportsData)
   end
 end

--- a/lib/pool_web/controllers/hub_controller.ex
+++ b/lib/pool_web/controllers/hub_controller.ex
@@ -3,9 +3,11 @@ defmodule PoolWeb.HubController do
 
   alias Pool.Weather
   alias Pool.SportsData
+  alias Pool.Games
 
   def index(conn, _params) do
     weather_data = Weather.get_weather()
-    render(conn, "index.html", weather: weather_data, team_data: SportsData)
+    games = Games.list_games()
+    render(conn, "index.html", games: games, weather: weather_data, team_data: SportsData)
   end
 end

--- a/lib/pool_web/controllers/hub_controller.ex
+++ b/lib/pool_web/controllers/hub_controller.ex
@@ -2,7 +2,6 @@ defmodule PoolWeb.HubController do
   use PoolWeb, :controller
 
   alias Pool.Weather
-  alias Pool.SportsData
   alias Pool.Games
   alias Pool.Contests
 
@@ -11,6 +10,12 @@ defmodule PoolWeb.HubController do
     games = Games.list_games()
     contests = Contests.list_contests()
     date = DateTime.utc_now()
-    render(conn, "index.html", games: games, contests: contests, date: date, weather: weather_data, team_data: SportsData)
+
+    render(conn, "index.html",
+      games: games,
+      contests: contests,
+      date: date,
+      weather: weather_data
+    )
   end
 end

--- a/lib/pool_web/controllers/hub_controller.ex
+++ b/lib/pool_web/controllers/hub_controller.ex
@@ -4,11 +4,13 @@ defmodule PoolWeb.HubController do
   alias Pool.Weather
   alias Pool.SportsData
   alias Pool.Games
+  alias Pool.Contests
 
   def index(conn, _params) do
     weather_data = Weather.get_weather()
     games = Games.list_games()
+    contests = Contests.list_contests()
     date = DateTime.utc_now()
-    render(conn, "index.html", games: games, date: date, weather: weather_data, team_data: SportsData)
+    render(conn, "index.html", games: games, contests: contests, date: date, weather: weather_data, team_data: SportsData)
   end
 end

--- a/lib/pool_web/controllers/hub_controller.ex
+++ b/lib/pool_web/controllers/hub_controller.ex
@@ -1,12 +1,10 @@
 defmodule PoolWeb.HubController do
   use PoolWeb, :controller
 
-  alias Pool.Weather
   alias Pool.Games
   alias Pool.Contests
 
   def index(conn, _params) do
-    weather_data = Weather.get_weather()
     games = Games.list_games()
     contests = Contests.list_contests()
     date = DateTime.utc_now()
@@ -14,8 +12,7 @@ defmodule PoolWeb.HubController do
     render(conn, "index.html",
       games: games,
       contests: contests,
-      date: date,
-      weather: weather_data
+      date: date
     )
   end
 end

--- a/lib/pool_web/controllers/hub_controller.ex
+++ b/lib/pool_web/controllers/hub_controller.ex
@@ -8,6 +8,7 @@ defmodule PoolWeb.HubController do
   def index(conn, _params) do
     weather_data = Weather.get_weather()
     games = Games.list_games()
-    render(conn, "index.html", games: games, weather: weather_data, team_data: SportsData)
+    date = DateTime.utc_now()
+    render(conn, "index.html", games: games, date: date, weather: weather_data, team_data: SportsData)
   end
 end

--- a/lib/pool_web/templates/contest/my_contests.html.heex
+++ b/lib/pool_web/templates/contest/my_contests.html.heex
@@ -35,7 +35,13 @@
           <!-- next picks due -->
           <div class="md:col-span-2 col-start-2 col-span-2 row-span-2 justify-self-center my-auto text-sm text-theme-darkgray  text-center md:text-center">
             <h4 class="md:text-md font-medium">Next Picks Due</h4>
-            <p class="inline-block md:block">[date/time]</p>
+            <!--p class="inline-block md:block"><%= next_picks_due(contest.id) %></p-->
+            <div class="timer" :class="time().days < 1 ? 'text-red-500' : (time().days < 2 && 'text-orange-400')" x-data={"timer(#{next_picks_due(contest.id)})"} x-init="init();">
+              <p class="inline-block" x-text="time().days + 'd'"></p>
+              <p class="inline-block" x-text="time().hours + 'h'"></p>
+              <p class="inline-block" x-text="time().minutes + 'm'"></p>
+              <p class="inline-block" x-text="time().seconds + 's'"></p>
+            </div>
             <div class="inline-block md:ml-0 ml-2">
               <i class="fa-regular fa-circle-check text-green-500 hidden"></i>
               <i class="fa-regular fa-exclamation-circle text-orange-400 hidden"></i>
@@ -66,3 +72,4 @@
     </div>
   </div>
 </div>
+<script type="text/javascript" src={Routes.static_path(@conn, "/images/custom.js")}></script>

--- a/lib/pool_web/templates/hub/index.html.heex
+++ b/lib/pool_web/templates/hub/index.html.heex
@@ -88,10 +88,11 @@
           <div x-show="open" class="grid grid-cols-9 py-4 text-xs text-center">
             <!-- weather -->
             <div class="col-start-4 col-span-2 justify-self-end flex flex-row items-center text-theme-darkgray">
-              <div class="text-2xl pr-4"><i class={get_forecast(game.id)[:icon]}></i></div>
+              <%# <div class="text-2xl pr-4"><i class={get_forecast(game.id)[:icon]}></i></div> %>
+              <div class="text-2xl pr-4"><i class={weather_icon(game.forecast_desc)}></i></div>
               <div class="flex flex-col">
-                <p class="pr-2"><%= get_forecast(game.id)[:temp] %>&#8457;</p>
-                <p class="pr-2"><%= get_forecast(game.id)[:wind] %> mph</p>
+                <p class="pr-2"><%= game.forecast_temp %>&#8457;</p>
+                <p class="pr-2"><%= game.forecast_wind %> mph</p>
               </div>
             </div>
             <!-- stadium -->

--- a/lib/pool_web/templates/hub/index.html.heex
+++ b/lib/pool_web/templates/hub/index.html.heex
@@ -51,7 +51,7 @@
     <!-- games container -->
     <div class="mx-auto grid auto-rows-auto w-full h-fit max-h-min min-h-full text-center border border-slate-200 rounded-xl divide-y divide-inherit bg-white">
       <!-- for loop start -->
-      <%= for game <- @games do %>
+      <%= for game when game.start > @date <- @games  do %>
         <div x-data="{ open: false }">
           <!-- game row -->
           <div class="grid justify-items-center grid-cols-12 grid-rows-4 md:gap-x-1 gap-y-0 md:p-4 px-2 py-2 min-h-max text-theme-darkgray">

--- a/lib/pool_web/templates/hub/index.html.heex
+++ b/lib/pool_web/templates/hub/index.html.heex
@@ -11,7 +11,7 @@
     <!-- contests container -->
     <div class="mx-auto grid auto-rows-auto w-full h-fit max-h-min min-h-full text-center border border-slate-200 rounded-xl divide-y divide-inherit bg-white">
       <!-- for loop start -->
-      <%= for contest <- Contests.joined_contests(@current_user.id) do %>
+      <%= for contest <- Contests.joined_contests_needing_picks(@current_user.id) do %>
         <!-- contest row -->
         <div class="grid justify-items-center grid-cols-6 grid-rows-2 md:grid-rows-1 md:gap-x-1 gap-y-0 md:p-4 px-2 py-2 min-h-max">
           <!-- avatar -->

--- a/lib/pool_web/templates/hub/index.html.heex
+++ b/lib/pool_web/templates/hub/index.html.heex
@@ -69,9 +69,9 @@
             <!-- at -->
             <p class="col-start-5 col-span-3 row-start-2 row-span-2 self-center text-md">at</p>
             <!-- over/under -->
-            <p class="col-start-5 col-span-3 row-start-4 text-xs font-medium">O/U 48.5</p>
+            <p class="col-start-5 col-span-3 row-start-4 text-xs font-medium">O/U <%= game.over_under %></p>
             <!-- spread -->
-            <p class="col-start-8 col-span-1 row-start-4 text-xs font-medium">-4</p>
+            <p class="col-start-8 col-span-1 row-start-4 text-xs font-medium"><%= game.spread %></p>
             <!-- home team -->
             <div class="col-start-8 col-span-4 row-start-1 row-span-4 self-center pt-2">
               <img class="w-12 h-12 object-scale-down py-1" src={game.home_team.logo} alt="">

--- a/lib/pool_web/templates/hub/index.html.heex
+++ b/lib/pool_web/templates/hub/index.html.heex
@@ -57,14 +57,14 @@
       <%= for game <- @games do %>
         <div x-data="{ open: false }">
           <!-- game row -->
-          <div class="grid justify-items-center grid-cols-12 grid-rows-4 md:gap-x-1 gap-y-0 md:p-4 px-2 py-2 min-h-max text-theme-darkgray">
+          <div x-data={"{homeFavorite: #{home_favorite(game.spread)} }"} class="grid justify-items-center grid-cols-12 grid-rows-4 md:gap-x-1 gap-y-0 md:p-4 px-2 py-2 min-h-max text-theme-darkgray">
             <!-- away team -->
             <div class="col-start-1 col-span-3 row-start-1 row-span-4 self-center pt-2">
               <img class="w-12 h-12 object-scale-down py-1" src={game.away_team.logo} alt="">
               <p class="text-sm"><%= game.away_team.key %></p>
             </div>
             <!-- spread -->
-            <p class="col-start-4 col-span-1 row-start-4 text-xs font-medium"></p>
+            <p x-show="!homeFavorite" class="col-start-4 col-span-1 row-start-4 text-xs font-medium">-<%= game.spread %></p>
             <!-- game time -->
             <p class="col-start-4 col-span-5 row-start-1 text-xs"><%= format_date(game.start) %></p>
             <!-- at -->
@@ -72,7 +72,7 @@
             <!-- over/under -->
             <p class="col-start-5 col-span-3 row-start-4 text-xs font-medium">O/U <%= game.over_under %></p>
             <!-- spread -->
-            <p class="col-start-8 col-span-1 row-start-4 text-xs font-medium"><%= game.spread %></p>
+            <p x-show="homeFavorite" class="col-start-8 col-span-1 row-start-4 text-xs font-medium"><%= game.spread %></p>
             <!-- home team -->
             <div class="col-start-9 col-span-3 row-start-1 row-span-4 self-center pt-2">
               <img class="w-12 h-12 object-scale-down py-1" src={game.home_team.logo} alt="">

--- a/lib/pool_web/templates/hub/index.html.heex
+++ b/lib/pool_web/templates/hub/index.html.heex
@@ -53,7 +53,8 @@
     <!-- games container -->
     <div class="mx-auto grid auto-rows-auto w-full h-fit max-h-min min-h-full text-center border border-slate-200 rounded-xl divide-y divide-inherit bg-white">
       <!-- for loop start -->
-      <%= for game when game.start > @date <- @games  do %>
+      <!--%= for game when game.start > @date <- @games do %-->
+      <%= for game <- @games do %>
         <div x-data="{ open: false }">
           <!-- game row -->
           <div class="grid justify-items-center grid-cols-12 grid-rows-4 md:gap-x-1 gap-y-0 md:p-4 px-2 py-2 min-h-max text-theme-darkgray">

--- a/lib/pool_web/templates/hub/index.html.heex
+++ b/lib/pool_web/templates/hub/index.html.heex
@@ -11,36 +11,38 @@
     <!-- contests container -->
     <div class="mx-auto grid auto-rows-auto w-full h-fit max-h-min min-h-full text-center border border-slate-200 rounded-xl divide-y divide-inherit bg-white">
       <!-- for loop start -->
-      <!-- contest row -->
-      <div class="grid justify-items-center grid-cols-6 grid-rows-2 md:grid-rows-1 md:gap-x-1 gap-y-0 md:p-4 px-2 py-2 min-h-max">
-        <!-- avatar -->
-        <div class="my-auto w-12 md:w-16 row-span-2 md:row-span-1 justify-self-start lg:justify-self-center">
-          <a href="#">
-            <img class="mx-auto my-auto text-center ring-2 ring-theme-blue nontouch:hover:ring-2 nontouch:hover:ring-theme-blue-light nontouch:active:ring-theme-blue-dark focus:ring-2 focus:ring-theme-blue-light rounded-full transition-all ease-in-out duration-200"
-            src="https://picsum.photos/200" alt="">
-          </a>
-        </div>
-        <!-- contest name -->
-        <div class="col-start-2 col-span-3 md:col-span-2 md:w-auto w-fit justify-self-start my-auto text-left pl-2 md:pl-0 font-medium text-theme-blue nontouch:hover:text-theme-blue-light nontouch:active:text-theme-blue-dark active:text-theme-blue-dark text-md md:text-xl xl:text-2xl transition-all ease-in-out duration-200">
-          <a href="#">
-            <h4>Contest Name</h4>
-          </a>
-        </div>
-        <!-- next picks due -->
-        <div class="col-start-2 col-span-3 md:col-start-4 md:col-span-2 justify-self-center my-auto text-sm text-theme-darkgray text-center font-medium">
-          <h4 class="md:text-md font-medium">Next Picks Due</h4>
-          <div class="timer" :class="time().days < 1 ? 'text-red-500' : (time().days < 2 && 'text-orange-400')" x-data="timer(new Date(2022,3,13,18,30))" x-init="init();">
-            <p class="inline-block" x-text="time().days + 'd'"></p>
-            <p class="inline-block" x-text="time().hours + 'h'"></p>
-            <p class="inline-block" x-text="time().minutes + 'm'"></p>
-            <p class="inline-block" x-text="time().seconds + 's'"></p>
+      <%= for contest <- @contests do %>
+        <!-- contest row -->
+        <div class="grid justify-items-center grid-cols-6 grid-rows-2 md:grid-rows-1 md:gap-x-1 gap-y-0 md:p-4 px-2 py-2 min-h-max">
+          <!-- avatar -->
+          <div class="my-auto w-12 md:w-16 row-span-2 md:row-span-1 justify-self-start lg:justify-self-center">
+            <%= link to: Routes.contest_path(@conn, :show, contest) do %>
+              <img class="object-cover w-12 h-12 mx-auto my-auto ring-2 ring-theme-blue nontouch:hover:ring-2 nontouch:hover:ring-theme-blue-light nontouch:active:ring-theme-blue-dark focus:ring-2 focus:ring-theme-blue-light rounded-full transition-all ease-in-out duration-200"
+                        src={contest.avatar} alt="">
+            <% end %>
           </div>
+          <!-- contest name -->
+          <div class="col-start-2 col-span-3 md:col-span-2 md:w-auto w-fit justify-self-start my-auto text-left pl-2 md:pl-0 font-medium text-theme-blue nontouch:hover:text-theme-blue-light nontouch:active:text-theme-blue-dark active:text-theme-blue-dark text-md md:text-xl xl:text-2xl transition-all ease-in-out duration-200">
+            <%= link to: Routes.contest_path(@conn, :show, contest) do %>
+              <h4><%= contest.name %></h4>
+            <% end %>
+          </div>
+          <!-- next picks due -->
+          <div class="col-start-2 col-span-3 md:col-start-4 md:col-span-2 justify-self-center my-auto text-sm text-theme-darkgray text-center font-medium">
+            <h4 class="md:text-md font-medium">Next Picks Due</h4>
+            <div class="timer" :class="time().days < 1 ? 'text-red-500' : (time().days < 2 && 'text-orange-400')" x-data="timer(new Date(2022,3,13,18,30))" x-init="init();">
+              <p class="inline-block" x-text="time().days + 'd'"></p>
+              <p class="inline-block" x-text="time().hours + 'h'"></p>
+              <p class="inline-block" x-text="time().minutes + 'm'"></p>
+              <p class="inline-block" x-text="time().seconds + 's'"></p>
+            </div>
+          </div>
+          <!-- action button -->
+          <%= link to: Routes.contest_path(@conn, :show, contest), class: "my-auto col-start-5 col-span-2 md:col-start-6 row-start-1 row-span-2 md:row-span-1 w-auto md:w-max self-center justify-self-end md:justify-self-auto mr-2 md:mr-4 text-md md:text-lg bg-theme-blue nontouch:hover:bg-theme-blue-light nontouch:active:bg-theme-blue-dark active:bg-theme-blue-dark text-white font-medium py-2 px-3 rounded transition-all ease-in-out duration-200" do %>
+            Pick Now
+          <% end %>
         </div>
-        <!-- action button -->
-        <button class="my-auto col-start-5 col-span-2 md:col-start-6 row-start-1 row-span-2 md:row-span-1 w-auto md:w-max self-center justify-self-end md:justify-self-auto mr-2 md:mr-4 text-md md:text-lg bg-theme-blue nontouch:hover:bg-theme-blue-light nontouch:active:bg-theme-blue-dark active:bg-theme-blue-dark text-white font-medium py-2 px-3 rounded transition-all ease-in-out duration-200">
-          Pick Now
-        </button>
-      </div>
+      <% end %>
       <!-- for loop end -->
     </div>
   </div>

--- a/lib/pool_web/templates/hub/index.html.heex
+++ b/lib/pool_web/templates/hub/index.html.heex
@@ -11,7 +11,7 @@
     <!-- contests container -->
     <div class="mx-auto grid auto-rows-auto w-full h-fit max-h-min min-h-full text-center border border-slate-200 rounded-xl divide-y divide-inherit bg-white">
       <!-- for loop start -->
-      <%= for contest <- @contests do %>
+      <%= for contest <- Contests.joined_contests(@current_user.id) do %>
         <!-- contest row -->
         <div class="grid justify-items-center grid-cols-6 grid-rows-2 md:grid-rows-1 md:gap-x-1 gap-y-0 md:p-4 px-2 py-2 min-h-max">
           <!-- avatar -->

--- a/lib/pool_web/templates/hub/index.html.heex
+++ b/lib/pool_web/templates/hub/index.html.heex
@@ -59,7 +59,7 @@
           <!-- game row -->
           <div class="grid justify-items-center grid-cols-12 grid-rows-4 md:gap-x-1 gap-y-0 md:p-4 px-2 py-2 min-h-max text-theme-darkgray">
             <!-- away team -->
-            <div class="col-start-1 col-span-4 row-start-1 row-span-4 self-center pt-2">
+            <div class="col-start-1 col-span-3 row-start-1 row-span-4 self-center pt-2">
               <img class="w-12 h-12 object-scale-down py-1" src={game.away_team.logo} alt="">
               <p class="text-sm"><%= game.away_team.key %></p>
             </div>
@@ -74,7 +74,7 @@
             <!-- spread -->
             <p class="col-start-8 col-span-1 row-start-4 text-xs font-medium"><%= game.spread %></p>
             <!-- home team -->
-            <div class="col-start-8 col-span-4 row-start-1 row-span-4 self-center pt-2">
+            <div class="col-start-9 col-span-3 row-start-1 row-span-4 self-center pt-2">
               <img class="w-12 h-12 object-scale-down py-1" src={game.home_team.logo} alt="">
               <p class="text-sm"><%= game.home_team.key %></p>
             </div>
@@ -86,13 +86,17 @@
           </div>
           <!-- game details -->
           <div x-show="open" class="grid grid-cols-9 py-4 text-xs text-center">
-            <div class="col-start-5 col-span-2 justify-self-end flex flex-row items-center text-theme-darkgray">
-              <%# <img class="w-1/2" src={@weather.icon} alt="weather"> %>
-              <div class="text-2xl pr-4"><i class={set_icon(@weather.code)}></i></div>
-              <p class="pr-2"><%= @weather.temp %>&#8457;</p>
+            <!-- weather -->
+            <div class="col-start-4 col-span-2 justify-self-end flex flex-row items-center text-theme-darkgray">
+              <div class="text-2xl pr-4"><i class={get_forecast(game.id)[:icon]}></i></div>
+              <div class="flex flex-col">
+                <p class="pr-2"><%= get_forecast(game.id)[:temp] %>&#8457;</p>
+                <p class="pr-2"><%= get_forecast(game.id)[:wind] %> mph</p>
+              </div>
             </div>
-            <div class="col-start-7 col-span-3 px-2">
-              <p><%= game.home_team.stadium_details["Name"] %></p>
+            <!-- stadium -->
+            <div class="col-start-6 col-span-4 px-2">
+              <p class="font-medium"><%= game.home_team.stadium_details["Name"] %></p>
               <p><%= game.home_team.stadium_details["City"] <> ", " <> game.home_team.stadium_details["State"] %></p>
             </div>
           </div>

--- a/lib/pool_web/templates/hub/index.html.heex
+++ b/lib/pool_web/templates/hub/index.html.heex
@@ -88,8 +88,8 @@
             <p class="pr-2"><%= @weather.temp %>&#8457;</p>
           </div>
           <div class="col-start-7 col-span-3 px-2">
-            <p>{stadium}</p>
-            <p>{locale}</p>
+            <p><%= stadium_details("LAR").name %></p>
+            <p><%= stadium_details("LAR").locale %></p>
           </div>
         </div>
       </div>

--- a/lib/pool_web/templates/hub/index.html.heex
+++ b/lib/pool_web/templates/hub/index.html.heex
@@ -29,7 +29,7 @@
         <!-- next picks due -->
         <div class="col-start-2 col-span-3 md:col-start-4 md:col-span-2 justify-self-center my-auto text-sm text-theme-darkgray text-center font-medium">
           <h4 class="md:text-md font-medium">Next Picks Due</h4>
-          <div class="timer" :class="time().days < 1 ? 'text-red-500' : (time().days < 2 && 'text-orange-400')" x-data="timer(new Date(2022,1,13,18,30))" x-init="init();">
+          <div class="timer" :class="time().days < 1 ? 'text-red-500' : (time().days < 2 && 'text-orange-400')" x-data="timer(new Date(2022,3,13,18,30))" x-init="init();">
             <p class="inline-block" x-text="time().days + 'd'"></p>
             <p class="inline-block" x-text="time().hours + 'h'"></p>
             <p class="inline-block" x-text="time().minutes + 'm'"></p>
@@ -51,49 +51,51 @@
     <!-- games container -->
     <div class="mx-auto grid auto-rows-auto w-full h-fit max-h-min min-h-full text-center border border-slate-200 rounded-xl divide-y divide-inherit bg-white">
       <!-- for loop start -->
-      <div x-data="{ open: false }">
-        <!-- game row -->
-        <div class="grid justify-items-center grid-cols-12 grid-rows-4 md:gap-x-1 gap-y-0 md:p-4 px-2 py-2 min-h-max text-theme-darkgray">
-          <!-- team 1 -->
-          <div class="col-start-1 col-span-4 row-start-1 row-span-4 self-center">
-            <img class="" src="https://sportteamslogo.com/api?key=002d905d4ba94e708e355a4b3641f55a&size=medium&tid=4416" alt="">
-            <p class="text-sm">CIN</p>
+      <%= for game <- @games do %>
+        <div x-data="{ open: false }">
+          <!-- game row -->
+          <div class="grid justify-items-center grid-cols-12 grid-rows-4 md:gap-x-1 gap-y-0 md:p-4 px-2 py-2 min-h-max text-theme-darkgray">
+            <!-- away team -->
+            <div class="col-start-1 col-span-4 row-start-1 row-span-4 self-center pt-2">
+              <img class="w-12 h-12 object-scale-down py-1" src={game.away_team.logo} alt="">
+              <p class="text-sm"><%= game.away_team.key %></p>
+            </div>
+            <!-- spread -->
+            <p class="col-start-4 col-span-1 row-start-4 text-xs font-medium"></p>
+            <!-- game time -->
+            <p class="col-start-4 col-span-5 row-start-1 text-xs"><%= format_date(game.start) %></p>
+            <!-- at -->
+            <p class="col-start-5 col-span-3 row-start-2 row-span-2 self-center text-md">at</p>
+            <!-- over/under -->
+            <p class="col-start-5 col-span-3 row-start-4 text-xs font-medium">O/U 48.5</p>
+            <!-- spread -->
+            <p class="col-start-8 col-span-1 row-start-4 text-xs font-medium">-4</p>
+            <!-- home team -->
+            <div class="col-start-8 col-span-4 row-start-1 row-span-4 self-center pt-2">
+              <img class="w-12 h-12 object-scale-down py-1" src={game.home_team.logo} alt="">
+              <p class="text-sm"><%= game.home_team.key %></p>
+            </div>
+            <!-- action button -->
+            <button @click="open = ! open" class="mx-auto my-auto col-start-12 row-start-2 row-span-2 text-xl md:text-3xl text-theme-blue nontouch:hover:text-theme-blue-light nontouch:active:text-theme-blue-dark active:text-theme-blue-dark transition-all ease-in-out duration-200">
+              <i x-show="!open" class="fa-regular fa-angle-right"></i>
+              <i x-show="open" class="fa-regular fa-angle-down"></i>
+            </button>
           </div>
-          <!-- spread -->
-          <p class="col-start-4 col-span-1 row-start-4 text-xs font-medium"></p>
-          <!-- game time -->
-          <p class="col-start-4 col-span-5 row-start-1 text-xs">Feb 13 6:30 PM</p>
-          <!-- at -->
-          <p class="col-start-5 col-span-3 row-start-2 row-span-2 self-center text-md">at</p>
-          <!-- over/under -->
-          <p class="col-start-5 col-span-3 row-start-4 text-xs font-medium">O/U 48.5</p>
-          <!-- spread -->
-          <p class="col-start-8 col-span-1 row-start-4 text-xs font-medium">-4</p>
-          <!-- team 2 -->
-          <div class="col-start-8 col-span-4 row-start-1 row-span-4 self-center">
-            <img class="" src="https://sportteamslogo.com/api?key=002d905d4ba94e708e355a4b3641f55a&size=medium&tid=4387" alt="">
-            <p class="text-sm">LAR</p>
+          <!-- game details -->
+          <div x-show="open" class="grid grid-cols-9 py-4 text-xs text-center">
+            <div class="col-start-5 col-span-2 justify-self-end flex flex-row items-center text-theme-darkgray">
+              <%# <img class="w-1/2" src={@weather.icon} alt="weather"> %>
+              <div class="text-2xl pr-4"><i class={set_icon(@weather.code)}></i></div>
+              <p class="pr-2"><%= @weather.temp %>&#8457;</p>
+            </div>
+            <div class="col-start-7 col-span-3 px-2">
+              <p><%= game.home_team.stadium_details["Name"] %></p>
+              <p><%= game.home_team.stadium_details["City"] <> ", " <> game.home_team.stadium_details["State"] %></p>
+            </div>
           </div>
-          <!-- action button -->
-          <button @click="open = ! open" class="mx-auto my-auto col-start-12 row-start-2 row-span-2 text-xl md:text-3xl text-theme-blue nontouch:hover:text-theme-blue-light nontouch:active:text-theme-blue-dark active:text-theme-blue-dark transition-all ease-in-out duration-200">
-            <i x-show="!open" class="fa-regular fa-angle-right"></i>
-            <i x-show="open" class="fa-regular fa-angle-down"></i>
-          </button>
         </div>
-        <!-- game details -->
-        <div x-show="open" class="grid grid-cols-9 py-4 text-xs text-center">
-          <div class="col-start-5 col-span-2 justify-self-end flex flex-row items-center text-theme-darkgray">
-            <%# <img class="w-1/2" src={@weather.icon} alt="weather"> %>
-            <div class="text-2xl pr-4"><i class={set_icon(@weather.code)}></i></div>
-            <p class="pr-2"><%= @weather.temp %>&#8457;</p>
-          </div>
-          <div class="col-start-7 col-span-3 px-2">
-            <p><%= stadium_details("LAR").name %></p>
-            <p><%= stadium_details("LAR").locale %></p>
-          </div>
-        </div>
-      </div>
-      <!-- for loop end -->
+        <!-- for loop end -->
+      <% end %>
     </div>
   </div>
 </div>

--- a/lib/pool_web/views/contest_view.ex
+++ b/lib/pool_web/views/contest_view.ex
@@ -1,8 +1,16 @@
 defmodule PoolWeb.ContestView do
   use PoolWeb, :view
+  alias Pool.Contests
 
   def set_avatar() do
     img_id = to_string(Enum.random(1..200))
     "https://picsum.photos/id/" <> img_id <> "/200/300"
+  end
+
+  def next_picks_due(contest_id) do
+    hd(Contests.next_game_start(contest_id))
+    |> DateTime.to_unix()
+    # |> Date.to_gregorian_days()
+    # |> to_string()
   end
 end

--- a/lib/pool_web/views/hub_view.ex
+++ b/lib/pool_web/views/hub_view.ex
@@ -1,36 +1,64 @@
 defmodule PoolWeb.HubView do
   use PoolWeb, :view
   alias Pool.Contests
+  alias Pool.SportsData
 
-  # sets weather icon
-  def set_icon(code) do
-    case code do
-      "01d" -> "fa-solid fa-sun"
-      "01n" -> "fa-solid fa-moon-stars"
-      "02d" -> "fa-solid fa-sun-cloud"
-      "02n" -> "fa-solid fa-moon-cloud"
-      "03d" -> "fa-solid fa-cloud-sun"
-      "03n" -> "fa-solid fa-cloud-moon"
-      "04d" -> "fa-solid fa-clouds-sun"
-      "04n" -> "fa-solid fa-clouds-moon"
-      "09d" -> "fa-solid fa-cloud-drizzle"
-      "09n" -> "fa-solid fa-cloud-moon-rain"
-      "10d" -> "fa-solid fa-cloud-rain"
-      "10n" -> "fa-solid fa-cloud-moon-rain"
-      "11d" -> "fa-solid fa-cloud-bolt"
-      "11n" -> "fa-solid fa-cloud-bolt-moon"
-      "13d" -> "fa-solid fa-snowflakes"
-      "13n" -> "fa-solid fa-snowflakes"
-      "50d" -> "fa-solid fa-cloud-fog"
-      "50n" -> "fa-solid fa-cloud-fog"
+  def get_forecast(game_id) do
+    game = Enum.find(SportsData.get_all_games(), fn g -> g["GlobalGameID"] == game_id end)
+    [temp: game["ForecastWindChill"], icon: weather_icon(game["ForecastDescription"]), wind: game["ForecastWindSpeed"]]
+  end
+
+  # sets weather icon (based on sportsdata game-time forecast description)
+  def weather_icon(desc) do
+    case desc do
+      "Clear Sky" -> "fa-solid fa-sun"
+      "Few Clouds" -> "fa-solid fa-sun-cloud"
+      "Scattered Clouds" -> "fa-solid fa-cloud-sun"
+      "Broken Clouds" -> "fa-solid fa-cloud-sun"
+      "Overcast Clouds" -> "fa-solid fa-clouds-sun"
+      "Light Rain" -> "fa-solid fa-cloud-drizzle"
+      "Moderate Rain" -> "fa-solid fa-cloud-rain"
+      "Heavy Intensity Rain" -> "fa-solid fa-cloud-rain"
+      "Snow" -> "fa-solid fa-snowflakes"
+      nil -> ""
+      # "Clear Sky" -> "fa-solid fa-moon-stars"
+      # "Few Clouds" -> "fa-solid fa-moon-cloud"
+      # "Scattered Clouds" -> "fa-solid fa-cloud-moon"
+      # "Overcast Clouds" -> "fa-solid fa-clouds-moon"
+      # "Heavy Intensity Rain" -> "fa-solid fa-cloud-moon-rain"
     end
   end
+
+  # sets weather icon (based on openweather code)
+  # def set_icon(code) do
+  #   case code do
+  #     "01d" -> "fa-solid fa-sun"
+  #     "01n" -> "fa-solid fa-moon-stars"
+  #     "02d" -> "fa-solid fa-sun-cloud"
+  #     "02n" -> "fa-solid fa-moon-cloud"
+  #     "03d" -> "fa-solid fa-cloud-sun"
+  #     "03n" -> "fa-solid fa-cloud-moon"
+  #     "04d" -> "fa-solid fa-clouds-sun"
+  #     "04n" -> "fa-solid fa-clouds-moon"
+  #     "09d" -> "fa-solid fa-cloud-drizzle"
+  #     "09n" -> "fa-solid fa-cloud-moon-rain"
+  #     "10d" -> "fa-solid fa-cloud-rain"
+  #     "10n" -> "fa-solid fa-cloud-moon-rain"
+  #     "11d" -> "fa-solid fa-cloud-bolt"
+  #     "11n" -> "fa-solid fa-cloud-bolt-moon"
+  #     "13d" -> "fa-solid fa-snowflakes"
+  #     "13n" -> "fa-solid fa-snowflakes"
+  #     "50d" -> "fa-solid fa-cloud-fog"
+  #     "50n" -> "fa-solid fa-cloud-fog"
+  #   end
+  # end
 
   # TODO -- format date/time properly
   def format_date(date) do
     "#{date.month}/#{date.day} #{date.hour}:#{date.minute}"
   end
 
+  # places the spread text next to the favorite team
   # def position_spread() do
   #   if Games.game.spread > 0 do
 

--- a/lib/pool_web/views/hub_view.ex
+++ b/lib/pool_web/views/hub_view.ex
@@ -24,4 +24,14 @@ defmodule PoolWeb.HubView do
       "50n" -> "fa-solid fa-cloud-fog"
     end
   end
+
+  def stadium_details(key) do
+    %{
+      name: Pool.SportsData.get_team_details(key).stadium_details["Name"],
+      locale:
+        Pool.SportsData.get_team_details(key).stadium_details["City"] <>
+          ", " <>
+          Pool.SportsData.get_team_details(key).stadium_details["State"]
+    }
+  end
 end

--- a/lib/pool_web/views/hub_view.ex
+++ b/lib/pool_web/views/hub_view.ex
@@ -1,5 +1,6 @@
 defmodule PoolWeb.HubView do
   use PoolWeb, :view
+  alias Pool.Contests
 
   # sets weather icon
   def set_icon(code) do

--- a/lib/pool_web/views/hub_view.ex
+++ b/lib/pool_web/views/hub_view.ex
@@ -29,4 +29,10 @@ defmodule PoolWeb.HubView do
   def format_date(date) do
     "#{date.month}/#{date.day} #{date.hour}:#{date.minute}"
   end
+
+  # def position_spread() do
+  #   if Games.game.spread > 0 do
+
+  #   end
+  # end
 end

--- a/lib/pool_web/views/hub_view.ex
+++ b/lib/pool_web/views/hub_view.ex
@@ -21,6 +21,7 @@ defmodule PoolWeb.HubView do
       "Heavy Intensity Rain" -> "fa-solid fa-cloud-rain"
       "Snow" -> "fa-solid fa-snowflakes"
       nil -> ""
+      # night time icons
       # "Clear Sky" -> "fa-solid fa-moon-stars"
       # "Few Clouds" -> "fa-solid fa-moon-cloud"
       # "Scattered Clouds" -> "fa-solid fa-cloud-moon"
@@ -58,10 +59,11 @@ defmodule PoolWeb.HubView do
     "#{date.month}/#{date.day} #{date.hour}:#{date.minute}"
   end
 
-  # places the spread text next to the favorite team
-  # def position_spread() do
-  #   if Games.game.spread > 0 do
-
-  #   end
-  # end
+  # determines favorite for DOM spread placement
+  def home_favorite(home_spread) do
+    if home_spread > 0 do
+      false
+    end
+    true
+  end
 end

--- a/lib/pool_web/views/hub_view.ex
+++ b/lib/pool_web/views/hub_view.ex
@@ -25,13 +25,8 @@ defmodule PoolWeb.HubView do
     end
   end
 
-  def stadium_details(key) do
-    %{
-      name: Pool.SportsData.get_team_details(key).stadium_details["Name"],
-      locale:
-        Pool.SportsData.get_team_details(key).stadium_details["City"] <>
-          ", " <>
-          Pool.SportsData.get_team_details(key).stadium_details["State"]
-    }
+  # TODO -- format date/time properly
+  def format_date(date) do
+    "#{date.month}/#{date.day} #{date.hour}:#{date.minute}"
   end
 end

--- a/priv/repo/migrations/20220313015111_add_fields_to_teams.exs
+++ b/priv/repo/migrations/20220313015111_add_fields_to_teams.exs
@@ -3,12 +3,11 @@ defmodule Pool.Repo.Migrations.AddFieldsToTeams do
 
   def change do
     alter table(:teams) do
-      add :name, :string
       add :city, :string
       add :key, :string
       add :conference, :string
       add :division, :string
-      add :stadium_details, :string
+      add :stadium_details, :map
       add :colors, {:map, :string}
     end
   end

--- a/priv/repo/migrations/20220313015111_add_fields_to_teams.exs
+++ b/priv/repo/migrations/20220313015111_add_fields_to_teams.exs
@@ -3,6 +3,7 @@ defmodule Pool.Repo.Migrations.AddFieldsToTeams do
 
   def change do
     alter table(:teams) do
+      add :global_id, :integer
       add :city, :string
       add :key, :string
       add :conference, :string

--- a/priv/repo/migrations/20220313015111_add_fields_to_teams.exs
+++ b/priv/repo/migrations/20220313015111_add_fields_to_teams.exs
@@ -1,0 +1,15 @@
+defmodule Pool.Repo.Migrations.AddFieldsToTeams do
+  use Ecto.Migration
+
+  def change do
+    alter table(:teams) do
+      add :name, :string
+      add :city, :string
+      add :key, :string
+      add :conference, :string
+      add :division, :string
+      add :stadium_details, :string
+      add :colors, {:map, :string}
+    end
+  end
+end

--- a/priv/repo/migrations/20220724173946_add_weather_to_game.exs
+++ b/priv/repo/migrations/20220724173946_add_weather_to_game.exs
@@ -1,0 +1,11 @@
+defmodule Pool.Repo.Migrations.AddWeatherToGame do
+  use Ecto.Migration
+
+  def change do
+    alter table(:games) do
+      add :forecast_temp, :integer
+      add :forecast_desc, :string
+      add :forecast_wind, :integer
+    end
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -59,9 +59,12 @@ for i <- 1..contest_count do
 end
 
 # -- GENERATE TEAMS -- #
-SportsData.get_all_teams("Key") |> Enum.with_index() |> Enum.each(fn {k, i} ->
+SportsData.get_all_teams("Key")
+|> Enum.with_index()
+|> Enum.each(fn {k, i} ->
   Repo.insert!(%Games.Team{
-    id: i + 1,
+    id: SportsData.get_team_details(k).global_id,
+    global_id: SportsData.get_team_details(k).global_id,
     logo: SportsData.get_team_details(k).logo,
     name: SportsData.get_team_details(k).full_name,
     city: SportsData.get_team_details(k).city,
@@ -76,19 +79,17 @@ SportsData.get_all_teams("Key") |> Enum.with_index() |> Enum.each(fn {k, i} ->
 end)
 
 # -- GENERATE GAMES -- #
-game_count = 16
-for i <- 1..game_count do
-  home = i
-  away = 33 - home
-
+Enum.filter(SportsData.get_all_games(), fn g -> g["GlobalGameID"] != 0 && g["Week"] == 1 end)
+|> Enum.with_index()
+|> Enum.each(fn {game, i} ->
   Repo.insert!(%Games.Game{
-    id: i,
-    over_under: Enum.random(60..130) / 2,
-    spread: Enum.random(1..30) / 2,
+    id: i + 1,
+    over_under: game["OverUnder"],
+    spread: game["PointSpread"],
     start: DateTime.truncate(Faker.DateTime.forward(14), :second),
-    home_team_id: home,
-    away_team_id: away,
+    home_team_id: game["GlobalHomeTeamID"],
+    away_team_id: game["GlobalAwayTeamID"],
     inserted_at: NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second),
     updated_at: NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second)
   })
-end
+end)

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -59,16 +59,17 @@ for i <- 1..contest_count do
 end
 
 # -- GENERATE TEAMS -- #
-teams_data = %{
-  name: SportsData.get_all_teams("FullName"),
-  logo: SportsData.get_all_teams("WikipediaLogoUrl")
-}
-
 for i <- 1..32 do
   Repo.insert!(%Games.Team{
     id: i,
-    logo: Enum.at(teams_data.logo, i - 1),
-    name: Enum.at(teams_data.name, i - 1),
+    logo: SportsData.get_team_details_by_id(i).logo,
+    name: SportsData.get_team_details_by_id(i).full_name,
+    city: SportsData.get_team_details_by_id(i).city,
+    key: SportsData.get_team_details_by_id(i).key,
+    conference: SportsData.get_team_details_by_id(i).conference,
+    division: SportsData.get_team_details_by_id(i).division,
+    stadium_details: SportsData.get_team_details_by_id(i).stadium_details,
+    colors: SportsData.get_team_details_by_id(i).colors,
     inserted_at: ~N[2022-02-26 17:06:16],
     updated_at: ~N[2022-02-26 17:06:16]
   })

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -51,32 +51,33 @@ for i <- 1..contest_count do
   Repo.insert!(%Contests.Contest{
     id: i,
     name: Faker.Pizza.topping() <> " " <> Faker.Superhero.suffix(),
-    inserted_at: ~N[2022-02-26 17:06:16],
-    updated_at: ~N[2022-02-26 17:06:16],
+    inserted_at: NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second),
+    updated_at: NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second),
     owner_account_id: :rand.uniform(3),
     avatar: PoolWeb.ContestView.set_avatar()
   })
 end
 
 # -- GENERATE TEAMS -- #
-for i <- 1..32 do
+SportsData.get_all_teams("Key") |> Enum.with_index() |> Enum.each(fn {k, i} ->
   Repo.insert!(%Games.Team{
-    id: i,
-    logo: SportsData.get_team_details_by_id(i).logo,
-    name: SportsData.get_team_details_by_id(i).full_name,
-    city: SportsData.get_team_details_by_id(i).city,
-    key: SportsData.get_team_details_by_id(i).key,
-    conference: SportsData.get_team_details_by_id(i).conference,
-    division: SportsData.get_team_details_by_id(i).division,
-    stadium_details: SportsData.get_team_details_by_id(i).stadium_details,
-    colors: SportsData.get_team_details_by_id(i).colors,
-    inserted_at: ~N[2022-02-26 17:06:16],
-    updated_at: ~N[2022-02-26 17:06:16]
+    id: i + 1,
+    logo: SportsData.get_team_details(k).logo,
+    name: SportsData.get_team_details(k).full_name,
+    city: SportsData.get_team_details(k).city,
+    key: SportsData.get_team_details(k).key,
+    conference: SportsData.get_team_details(k).conference,
+    division: SportsData.get_team_details(k).division,
+    stadium_details: SportsData.get_team_details(k).stadium_details,
+    colors: SportsData.get_team_details(k).colors,
+    inserted_at: NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second),
+    updated_at: NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second)
   })
-end
+end)
 
 # -- GENERATE GAMES -- #
-for i <- 1..div(32, 2) do
+game_count = 16
+for i <- 1..game_count do
   home = i
   away = 33 - home
 
@@ -87,7 +88,7 @@ for i <- 1..div(32, 2) do
     start: DateTime.truncate(Faker.DateTime.forward(14), :second),
     home_team_id: home,
     away_team_id: away,
-    inserted_at: ~N[2022-02-26 17:06:16],
-    updated_at: ~N[2022-02-26 17:06:16]
+    inserted_at: NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second),
+    updated_at: NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second)
   })
 end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -89,6 +89,9 @@ SportsData.get_game_odds_by_week()
     start: start,
     home_team_id: game["GlobalHomeTeamId"],
     away_team_id: game["GlobalAwayTeamId"],
+    forecast_temp: Enum.find(SportsData.get_all_games(), fn g -> g["GlobalGameID"] == game["GlobalGameId"] end)["ForecastWindChill"],
+    forecast_desc: Enum.find(SportsData.get_all_games(), fn g -> g["GlobalGameID"] == game["GlobalGameId"] end)["ForecastDescription"],
+    forecast_wind: Enum.find(SportsData.get_all_games(), fn g -> g["GlobalGameID"] == game["GlobalGameId"] end)["ForecastWindSpeed"],
     inserted_at: NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second),
     updated_at: NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second)
   })

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -79,16 +79,16 @@ SportsData.get_all_teams("Key")
 end)
 
 # -- GENERATE GAMES -- #
-Enum.filter(SportsData.get_all_games(), fn g -> g["GlobalGameID"] != 0 && g["Week"] == 1 end)
-|> Enum.with_index()
-|> Enum.each(fn {game, i} ->
+SportsData.get_game_odds_by_week()
+|> Enum.each(fn game ->
+  {:ok, start, 0} = DateTime.from_iso8601(game["DateTime"] <> "Z")
   Repo.insert!(%Games.Game{
-    id: i + 1,
-    over_under: game["OverUnder"],
-    spread: game["PointSpread"],
-    start: DateTime.truncate(Faker.DateTime.forward(14), :second),
-    home_team_id: game["GlobalHomeTeamID"],
-    away_team_id: game["GlobalAwayTeamID"],
+    id: game["GlobalGameId"],
+    over_under: SportsData.get_game_odds_details(game["GlobalGameId"]).pregame_odds["OverUnder"],
+    spread: SportsData.get_game_odds_details(game["GlobalGameId"]).pregame_odds["HomePointSpread"],
+    start: start,
+    home_team_id: game["GlobalHomeTeamId"],
+    away_team_id: game["GlobalAwayTeamId"],
     inserted_at: NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second),
     updated_at: NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second)
   })


### PR DESCRIPTION
**Requires:**
```
mix ecto.reset
mix run priv/repo/seeds.exs
```
Here, we've expanded our Teams and Games tables with data from SportsDataIO. On the frontend, we've incorporated the data into the user dashboard.

**Outstanding items to address:**

- Dashboard "picks needed" section needs filter for only contests with unpicked games. Currently shows all of a user's contests
- Weather data currently being pulled from sportsdata calls upon page render. Possibly move weather data to Games table and update records periodically. Highly inefficient at the moment - slow page load and high bandwidth usage.
- Match next picks due countdown timer to soonest game start time.